### PR TITLE
Change undodir regex conditional

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -61,7 +61,7 @@ if isdirectory(expand('~/.cache/vim'))
   if &backupdir =~# '^\.,'
     set backupdir^=~/.cache/vim/backup//
   endif
-  if exists('+undodir') && &undodir =~# '^\.,'
+  if exists('+undodir') && &undodir =~# '^\.\%(,\|$\)'
     set undodir^=~/.cache/vim/undo//
   endif
 endif


### PR DESCRIPTION
undodir is set to `'.'` by default.

`'^\.,\|$'` will accept the default and if `'.'` if the first on a list, the
option is set, as intended.

Tiny fix, Tim. undodir wasn't being set in a default env.
