### PR TITLE
Don't consider numbers with leading zeros octal

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -25,6 +25,8 @@ set autoindent
 set shiftround
 set smarttab
 
+set nrformats-=octal
+
 set ttimeout
 set ttimeoutlen=50
 


### PR DESCRIPTION
Octal numbers are almost exclusively used nowadays for utilities like
chmod. With this change numbers leading with zeros for padding are
incremented and decremented as expected.
