### PR TITLE
Honour $XDG_DATA_HOME for &directory setting

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -68,7 +68,7 @@ if &history < 1000
 endif
 set viminfo^=!
 
-let s:dir = has('win32') ? '~/Application Data/Vim' : match(system('uname'), "Darwin") > -1 ? '~/Library/Vim' : '~/.local/share/vim'
+let s:dir = has('win32') ? '~/Application Data/Vim' : match(system('uname'), "Darwin") > -1 ? '~/Library/Vim' : empty($XDG_DATA_HOME) ? '~/.local/share/vim' : '$XDG_DATA_HOME/vim'
 if isdirectory(expand(s:dir))
   if &directory =~# '^\.,'
     let &directory = expand(s:dir) . '/swap//,' . &directory


### PR DESCRIPTION
'~/.local/share' is only the fallback location for data files, see http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html .

I'm sure there is a far cleaner way to implement this, but I figured a nasty looking fix is better than an issue with no attempt at a fix ;)

Thanks,

James

PS. Love the concept of this repo!
