### PR TITLE
Set correct AppData dir for more Windows versions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,7 +32,7 @@ mostly `:set` calls.)  Here's a taste:
 * `'listchars'`: Makes `:set list` (visible whitespace) prettier.
 * `'scrolloff'`: Always show at least one line above/below the cursor.
 * `'directory'`: Dump swap files under `~/.local/share/vim/swap`,
-  `~/Library/Vim/swap`, or `~\Application Data\Vim\swap`, depending on your
+  `~/Library/Vim/swap`, or `%APPDATA%\Vim\swap`, depending on your
   platform.  Also `'backupdir'` and `'undodir'`.  The directories aren't
   created automatically, so try `mkdir -p ~/Library/Vim/{swap,backup,undo}`.
 * `nmap Y y$`: Make `Y` behave like `C` and `D`.
@@ -74,7 +74,7 @@ don't like them strewn all over the file system, you have a few options.
 
     * `~/.local/share/vim/undo` on Linux
     * `~/Library/Vim/undo` on OS X
-    * `~\Application Data\Vim\undo` on Windows
+    * `%APPDATA%\Vim\undo` on Windows
 
 2.  Provide your own preferred location in `'undodir'`:
 

--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -72,7 +72,7 @@ if !empty(&viminfo)
   set viminfo^=!
 endif
 
-let s:dir = has('win32') ? '~/Application Data/Vim' : match(system('uname'), "Darwin") > -1 ? '~/Library/Vim' : empty($XDG_DATA_HOME) ? '~/.local/share/vim' : '$XDG_DATA_HOME/vim'
+let s:dir = has('win32') ? '$APPDATA/Vim' : match(system('uname'), "Darwin") > -1 ? '~/Library/Vim' : empty($XDG_DATA_HOME) ? '~/.local/share/vim' : '$XDG_DATA_HOME/vim'
 if isdirectory(expand(s:dir))
   if &directory =~# '^\.,'
     let &directory = expand(s:dir) . '/swap//,' . &directory


### PR DESCRIPTION
Replace the hard-coded path with an environment variable supported by all versions of Windows since XP (`%APPDATA%` in Windows, `$APPDATA` to Vim).

By default, Windows XP stores Application Data in the folder:

```
C:\Documents and Settings\<username>\Application Data
```

Windows Vista and later store AppData in:

```
C:\Users\<username>\Application Data
```

or

```
C:\Users\<username>\AppData\Roaming
```

You can, if you really need to, read all about the gory details of AppData here:
http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx
