### PR TITLE
Allows user to opt-out of key remaps

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -98,10 +98,12 @@ if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
   runtime! macros/matchit.vim
 endif
 
-inoremap <C-U> <C-G>u<C-U>
-nnoremap & :&&<CR>
-xnoremap & :&&<CR>
-" Make Y consistent with C and D.  See :help Y.
-nnoremap Y y$
+if !exists('g:sensible_suppress_maps')
+  inoremap <C-U> <C-G>u<C-U>
+  nnoremap & :&&<CR>
+  xnoremap & :&&<CR>
+  " Make Y consistent with C and D.  See :help Y.
+  nnoremap Y y$
+endif
 
 " vim:set ft=vim et sw=2:


### PR DESCRIPTION
This patch allows a user to opt out of vim-sensible's key remappings by adding the line `let g:sensible_suppress_maps` in their `.vimrc` file, instead of requiring them to create an "after" script to undo the mappings.

(This is a pretty trivial change, and maybe a different variable name would be preferable in order to match your preferred naming conventions.  There wasn't an example to draw from inside this plugin, so I just used the first name that came to mind.  Please feel free to modify to fit your preferences.)
