### PR TITLE
Add hidden as sensible default

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -22,6 +22,7 @@ set backspace=indent,eol,start
 set complete-=i
 set showmatch
 set smarttab
+set hidden
 
 set nrformats-=octal
 set shiftround


### PR DESCRIPTION
hidden makes sense as a sensible default, especially for newer users, as it allows easily switching buffers without fear of losing what's edited in the current buffers, and without Vim complaining
