### PR TITLE
Enable syntax folding of XML

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -13,6 +13,7 @@ if has('autocmd')
 endif
 if has('syntax') && !exists('g:syntax_on')
   syntax enable
+  let g:xml_syntax_folding = 1
 endif
 
 " Use :help 'option' to see the documentation for the given option.


### PR DESCRIPTION
The documentation for this setting is at `help xml-folding`.

This won’t do anything unless you also `set foldmethod=syntax`.

I think that most users will like the way this makes working with XML easier more than they dislike the very slight slowdown in syntax highlighting.
