### PR TITLE
Remove unicode listchars to fix #57

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -54,9 +54,6 @@ endif
 
 if &listchars ==# 'eol:$'
   set listchars=tab:>\ ,trail:-,extends:>,precedes:<,nbsp:+
-  if !has('win32') && (&termencoding ==# 'utf-8' || &encoding ==# 'utf-8')
-    let &listchars = "tab:\u21e5 ,trail:\u2423,extends:\u21c9,precedes:\u21c7,nbsp:\u00b7"
-  endif
 endif
 
 if &shell =~# 'fish$'


### PR DESCRIPTION
As discussed in Issue #57, setting Unicode characters for
`listchars` is a problematic default because of the scrolling
performance impact incurred when one of the specified glyphs is missing
from the user's selected font.

An alternative approach would be to choose "safer" unicode characters
that are likely to exist in most fonts. Given that the purpose of
vim-sensible is to provide universal sane defaults it seems this would
be best left to the user's `.vimrc` or another plugin.
