### PR TITLE
On windows, change `&shell` to `$COMSPEC` if win32/64 vim.exe or gvim.exe is executed from inside bash

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -63,6 +63,13 @@ if &shell =~# 'fish$'
   set shell=/bin/bash
 endif
 
+"On windows, if gvim.exe is executed from cygwin bash shell, the shell
+"needs to be changed to the shell most plugins expect on windows.
+"This does not change &shell inside cygwin or msys vim.
+if ( has("win32") || has("win64") || has("win16") ) && &shell =~# 'bash$'
+  set shell=$COMSPEC " sets shell to correct path for cmd.exe
+endif
+
 set autoread
 set fileformats+=mac
 


### PR DESCRIPTION
Please consider this as an addition for vim-sensible.

Unfortunately many plugins assume that if `has("win32") || has("win64") || has("win16")` is true, then shell commands are being executed in `cmd.exe`.

Note: `$COMSPEC` is the full path to `cmd.exe`.

If you launch a native windows gvim (win32 or win64) (not cygwin gvim binary) from inside a cygwin bash shell, then `&shell` is `/bin/bash`. This causes various problems with plugins.  For a windows binary of `gvim.exe`, it is best to have `&shell=$COMSPEC`.

Bash is great... but cygwin users should use cygwin's vim if they desire to use bash as their `&shell`.

Native windows gvim.exe is often preferred over cygwin gvim because it doesn't require xwindows server.  So it is common to execute native windows gvim.exe from inside cygwin.  Hence the need for this addition to vim-sensible.
