### PR TITLE
Please don't include shiftround

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -23,7 +23,6 @@ set complete-=i
 set smarttab
 
 set nrformats-=octal
-set shiftround
 
 set ttimeout
 set ttimeoutlen=100


### PR DESCRIPTION
The shiftround setting breaks many common cases of multi-line indent and outdent for continuation lines.  For example, suppose I have the following code, in a buffer with 8-space indentation:

```
foo(x,
    y)
```

With the default settings, I can > those two lines, and end up with this:

```
        foo(x,
            y);
```

But with shiftround, I instead end up with:

```
        foo(x,
        y); 
```
