### PR TITLE
Removes default keybinding for ex-mode

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -88,4 +88,7 @@ endif
 
 inoremap <C-U> <C-G>u<C-U>
 
+" Remove keybinding for ex-mode (often hit on accident, rarely requested)
+nnoremap Q <nop>
+
 " vim:set ft=vim et sw=2:


### PR DESCRIPTION
Often vim users enter ex-mode and are confused how to exit.
`Q` is an easy key to hit unintentionally.
Ex-mode can still be entered with `:ex`.

I notice this is the only `nnoremap`. 
So this might not fit the style of vim-sensible.
NeoVim is having a [discussion](https://news.ycombinator.com/item?id=8340181) about removing `ex-mode`.
A loud complaint from vim users there is accidentally hitting `Q`, entering ex-mode.