### PR TITLE
Remember last location in the file

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -10,6 +10,11 @@ endif
 
 if has('autocmd')
   filetype plugin indent on
+
+  " Remember last location in file, but not for commit messages.
+  " see :help last-position-jump
+  au BufReadPost * if &filetype !~ '^git\c' && line("'\"") > 0 && line("'\"") <= line("$")
+    \| exe "normal! g`\"" | endif
 endif
 if has('syntax') && !exists('g:syntax_on')
   syntax enable


### PR DESCRIPTION
When a file is opened, the cursor will be positioned on the line where the cursor was when the file was last closed (see `:help last-position-jump`).

I think it is a very sensible default, because we immediately see where we last left off (e.g. a failing test).
