### PR TITLE
Delete comment char when joining commented lines

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -54,6 +54,10 @@ if &listchars ==# 'eol:$'
   set listchars=tab:>\ ,trail:-,extends:>,precedes:<,nbsp:+
 endif
 
+if v:version > 703 || v:version == 703 && has("patch541")
+  set formatoptions+=j " Delete comment character when joining commented lines
+endif
+
 if has('path_extra')
   setglobal tags-=./tags tags^=./tags;
 endif


### PR DESCRIPTION
Let's say we have the following Ruby file.

``` rb
# First line of Ruby comments,
# and second line of Ruby comments
```

Now our cursor is on the first line, and we press `J`.

Before:

``` rb
# First line of Ruby comments, # and second line of Ruby comments
```

After:

``` rb
# First line of Ruby comments, and second line of Ruby comments
```
