### PR TITLE
Enable mouse control if available.

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -15,6 +15,11 @@ if has('syntax') && !exists('g:syntax_on')
   syntax enable
 endif
 
+" In many terminal emulators the mouse works just fine, thus enable it.
+if has('mouse')
+    set mouse=a
+endif
+
 " Use :help 'option' to see the documentation for the given option.
 
 set autoindent


### PR DESCRIPTION
The mouse works just fine in most terminal emulators these days, so let's enable it if possible.

I yanked the lines from someone else, but I unfortunately I can't credit them since I don't remember who it was. 