### PR TITLE
Set langnoremap

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -80,6 +80,10 @@ if !empty(&viminfo)
 endif
 set sessionoptions-=options
 
+if has('langmap') && (v:version > 704 || v:version == 704 && has('patch502'))
+  set langnoremap
+endif
+
 " Allow color schemes to do bright colors without forcing bold.
 if &t_Co == 8 && $TERM !~# '^linux'
   set t_Co=16


### PR DESCRIPTION
The `langnoremap` option was added in Vim 7.4.502 to prevent the `langmap` setting from interfering with plugin mappings.

`langnoremap` is now set unconditionally in `$VIMRUNTIME/vimrc_example.vim`. In the words of the author of Vim, "most users will want it on".

---

Not sure about the organisation of `plugin/sensible.vim`, so I just put the code towards the bottom.
