### PR TITLE
if neovim nottimeout

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -26,6 +26,9 @@ set nrformats-=octal
 
 set ttimeout
 set ttimeoutlen=100
+if has('nvim')
+  set nottimeout
+endif
 
 set incsearch
 " Use <C-L> to clear the highlighting of :set hlsearch.


### PR DESCRIPTION
neovim has an issue with ttimeout because of how it's handling key input. See https://github.com/neovim/neovim/issues/2454 and https://github.com/neovim/neovim/issues/2093

I'm not sure if you're looking to support both vim and neovim.