### PR TITLE
Removes default keybinding `Q` for Ex-mode

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -92,4 +92,7 @@ endif
 
 inoremap <C-U> <C-G>u<C-U>
 
+" Remove keybinding for ex-mode (often hit on accident, rarely requested)
+nnoremap Q <nop>
+
 " vim:set ft=vim et sw=2:

--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -92,7 +92,9 @@ endif
 
 inoremap <C-U> <C-G>u<C-U>
 
-" Remove keybinding for ex-mode (often hit on accident, rarely requested)
-nnoremap Q <nop>
+" Remove keybinding for Ex-mode (often hit on accident, rarely desired)
+if maparg('Q', 'n') ==# ''
+  nnoremap Q <nop>
+endif
 
 " vim:set ft=vim et sw=2:


### PR DESCRIPTION

```
Q			Switch to "Ex" mode.  This is a bit like typing ":"
			commands one after another, except:
			- You don't have to keep pressing ":".
			- The screen doesn't get updated after each command.
			- There is no normal command-line editing.
			- Mappings and abbreviations are not used.
			In fact, you are editing the lines with the "standard"
			line-input editing commands (<Del> or <BS> to erase,
			CTRL-U to kill the whole line).
			Vim will enter this mode by default if it's invoked as
			"ex" on the command-line.
			Use the ":vi" command |:visual| to exit "Ex" mode.
			Note: In older versions of Vim "Q" formatted text,
			that is now done with |gq|.  But if you use the
			|vimrc_example.vim| script "Q" works like "gq".
```
[Helpdoc Q](https://github.com/vim/vim/blob/fc53ec1e9aac682a8524698240ed2bb6f7b0e300/runtime/doc/intro.txt#L670)

The keybinding `Q` for Ex-mode in vim trips me up from time to time.  Either while I am trying to press `Esc`, `~`, or quitting a file `:q`.  I have also watched many new users of vim accidentally enter this mode.  This mode being enabled by the keybinding `Q` was removed from Neovim.

This is a rebase of the previous PR #80.
