### PR TITLE
Fix bug in C-L mapping

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -30,7 +30,7 @@ set ttimeoutlen=100
 set incsearch
 " Use <C-L> to clear the highlighting of :set hlsearch.
 if maparg('<C-L>', 'n') ==# ''
-  nnoremap <silent> <C-L> :nohlsearch<C-R>has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>
+  nnoremap <silent> <C-L> :nohlsearch<C-R>=has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>
 endif
 
 set laststatus=2


### PR DESCRIPTION
The <C-R> should be <CR>, otherwise an error occurs when pressing C-L:
E492: Not an editor command: nohlsearchas('diff')?'|diffupdate':''