### PR TITLE
Remove `set showcmd`

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -35,7 +35,6 @@ endif
 
 set laststatus=2
 set ruler
-set showcmd
 set wildmenu
 
 if !&scrolloff


### PR DESCRIPTION
For #49 and #109. `set showcmd` can be very annoying.

Now, what I can't explain is that removing the `set` command resolves my issue of hjkl being echoed, yet `:help showcmd` states its Vim default value is "on." That does not seem to be the case, and if it were, then remove it anyway because it would be redundant.