### PR TITLE
Preserve fish as 'shell' for Vim 7.4.276 or later

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -61,7 +61,7 @@ if has('path_extra')
   setglobal tags-=./tags tags-=./tags; tags^=./tags;
 endif
 
-if &shell =~# 'fish$'
+if &shell =~# 'fish$' && (v:version < 704 || v:version == 704 && !has('patch276'))
   set shell=/bin/bash
 endif
 


### PR DESCRIPTION
As of 7.4.276, Vim understands how to run commands in subshells when
'shell' is fish.  This fixes the most common problems with running
external commands from Vim.

Plugins may still need to accommodate for fish, but fixing the cognitive
dissonance of having the user's shell changed outweighs the benefit to
lazy plugin writers.