### PR TITLE
Correct check for loaded_matchit

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -84,7 +84,7 @@ if &t_Co == 8 && $TERM !~# '^linux\|^Eterm'
 endif
 
 " Load matchit.vim, but only if the user hasn't installed a newer version.
-if !exists('g:loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
+if !exists('loaded_matchit') && findfile('plugin/matchit.vim', &rtp) ==# ''
   runtime! macros/matchit.vim
 endif
 


### PR DESCRIPTION
matchit uses 'let loaded_matchit' syntax instead of 'let
g:loaded_matchit'. See
https://github.com/vim/vim/blob/master/runtime/pack/dist/opt/matchit/plugin/matchit.vim#L45