### PR TITLE
fix if statement "&ttimeoutlen = -1"

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -24,7 +24,7 @@ set smarttab
 
 set nrformats-=octal
 
-if !has('nvim') && &ttimeoutlen = -1
+if !has('nvim') && &ttimeoutlen == -1
   set ttimeout
   set ttimeoutlen=100
 endif


### PR DESCRIPTION
I just installed the latest version of vim-sensible, and vim gave me the following error:
```
Error detected while processing /Users/harry/.vim/plugged/vim-sensible/plugin/sensible.vim:
line   27:
E15: Invalid expression: !has('nvim') && &ttimeoutlen = -1
Press ENTER or type command to continue
```
I'm not familiar with vimscript, but I think you meant `&ttimeoutlen == -1` instead of `&ttimeoutlen = -1`.