### PR TITLE
Map Q to gQ unless Q is mapped

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -35,6 +35,11 @@ if maparg('<C-L>', 'n') ==# ''
   nnoremap <silent> <C-L> :nohlsearch<C-R>=has('diff')?'<Bar>diffupdate':''<CR><CR><C-L>
 endif
 
+" Let Ex mode have normal command-line editing and completion
+if maparg('Q', 'n') == ''
+  nnoremap Q gQ
+endif
+
 set laststatus=2
 set ruler
 set wildmenu


### PR DESCRIPTION
Map Q to gQ unless Q is mapped

Q is used to enter Ex-mode.  By default this mode is very limited.  The user cannot use wildmenu, command-line completion, or command-line mappings from plugins such as [rsi.vim](https://github.com/tpope/vim-rsi) or [readline.vim](https://github.com/ryvnf/readline.vim).  This makes Ex-mode very annoying to use by default.

Vim has a command gQ which will enter Ex-mode, by really behaves as if the user is typing many `:` commands after another (see `:help gQ`).  This allows the user to use all command-line editing functionality which is normally available when entering `:` commands, and use mappings from `cmap` and `cnoremap`.  I think that the gQ behaivor should be default.

Many users map Q to either *no operation* or to gq, because entering Ex-mode by accident can be annoying.  Because of this we should check if Q has already been mapped before changing its behavior.