### PR TITLE
Set wildmode=longest,list,full

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -39,6 +39,8 @@ set laststatus=2
 set ruler
 set wildmenu
 
+set wildemode=longest,list,full
+
 if !&scrolloff
   set scrolloff=1
 endif

--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -39,7 +39,7 @@ set laststatus=2
 set ruler
 set wildmenu
 
-set wildemode=longest,list,full
+set wildmode=longest,list,full
 
 if !&scrolloff
   set scrolloff=1


### PR DESCRIPTION
Reopened after changing commit message:

Default wildmode "full" forces users to skim through all possible matches as soon as they press .
A more flexible behaviour could be to first show them a list of possible matches then they can type few characters and skim through a shorter list of possible matches.