### PR TITLE
Set shell in a more portable way via /usr/bin/env

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -64,7 +64,7 @@ if has('path_extra')
 endif
 
 if &shell =~# 'fish$' && (v:version < 704 || v:version == 704 && !has('patch276'))
-  set shell=/bin/bash
+  set shell=/usr/bin/env\ bash
 endif
 
 set autoread


### PR DESCRIPTION
On *BSD environments set shell to /bin/bash leads to error since bash isn't in the core system.