### PR TITLE
set completeopt+=menuone,noinsert,noselect

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -20,6 +20,7 @@ endif
 set autoindent
 set backspace=indent,eol,start
 set complete-=i
+set completeopt+=menuone,noinsert,noselect
 set smarttab
 
 set nrformats-=octal


### PR DESCRIPTION
As seen in most configs.
Every plugin that deals with completion in some way also suggests or requires this.
Closes #116.