### PR TITLE
Add 'cd -' to installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,7 @@ support:
     cd ~/.vim/pack/tpope/start
     git clone https://tpope.io/vim/sensible.git
     vim -u NONE -c "helptags sensible/doc" -c q
+    cd -
 
 ## Features
 


### PR DESCRIPTION
returns to previous directory.