### PR TITLE
Display non-printable chars by default

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -54,6 +54,7 @@ endif
 if &listchars ==# 'eol:$'
   set listchars=tab:>\ ,trail:-,extends:>,precedes:<,nbsp:+
 endif
+set list
 
 if v:version > 703 || v:version == 703 && has("patch541")
   set formatoptions+=j " Delete comment character when joining commented lines


### PR DESCRIPTION
Don't know if visible whitespaces are not enabled by default intentionally or not, but thought PR won't hurt. Somehow on Gentoo Linux this is enabled by default, so I had no need to change a thing in my `.vimrc`, but on Fedora it's not enabled by default.