### PR TITLE
Add safeguards for enabling filetype

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -8,7 +8,7 @@ else
   let g:loaded_sensible = 'yes'
 endif
 
-if has('autocmd')
+if has('autocmd') && !(exists("did_load_filetypes") && exists("did_indent_on"))
   filetype plugin indent on
 endif
 if has('syntax') && !exists('g:syntax_on')


### PR DESCRIPTION
This fixes double-sourcing bug when one is using vim-sensible with plugin manager like vim-plug.

Vim-plug runs `filetype indent plugin on` before vim-sensible is loaded as plugin, so vim-sensible should not run it second time to avoid situation described below. To reproduce, install vim-plug and create following `~/.vimrc.test`:

```vim
call plug#begin()
Plug 'tpope/vim-sensible'
call plug#end()
```

Now you can see that `filetype.vim`, `ftplugin.vim` and `indent.vim` are sourced two times by running following command:

```
rm -f /tmp/startup.log && vim -N -u ~/.vimrc.test --startuptime /tmp/startup.log -c q && cat /tmp/startup.log | grep sourcing
016.358  002.075  002.075: sourcing /Users/sheerun/.vim/autoload/plug.vim
027.024  000.296  000.296: sourcing /usr/local/share/vim/vimfiles/ftdetect/pullrequest.vim
028.341  010.996  010.700: sourcing /usr/local/share/vim/vim82/filetype.vim
029.822  000.240  000.240: sourcing /usr/local/share/vim/vim82/ftplugin.vim
030.858  000.136  000.136: sourcing /usr/local/share/vim/vim82/indent.vim
032.948  001.142  001.142: sourcing /usr/local/share/vim/vim82/syntax/syncolor.vim
033.254  001.674  000.532: sourcing /usr/local/share/vim/vim82/syntax/synload.vim
033.313  001.989  000.315: sourcing /usr/local/share/vim/vim82/syntax/syntax.vim
033.347  019.188  003.752: sourcing /Users/sheerun/.vimrc.test
033.361  000.169: sourcing vimrc file(s)
034.212  000.029  000.029: sourcing /usr/local/share/vim/vim82/filetype.vim
034.519  000.092  000.092: sourcing /usr/local/share/vim/vim82/ftplugin.vim
034.712  000.016  000.016: sourcing /usr/local/share/vim/vim82/indent.vim
036.180  000.310  000.310: sourcing /usr/local/Cellar/vim/8.2.1700/share/vim/vim82/pack/dist/opt/matchit/plugin/matchit.vim
036.249  001.003  000.693: sourcing /usr/local/share/vim/vim82/macros/matchit.vim
036.307  002.363  001.223: sourcing /Users/sheerun/.vim/plugged/vim-sensible/plugin/sensible.vim
037.247  000.072  000.072: sourcing /usr/local/share/vim/vim82/plugin/getscriptPlugin.vim
037.689  000.364  000.364: sourcing /usr/local/share/vim/vim82/plugin/gzip.vim
038.042  000.271  000.271: sourcing /usr/local/share/vim/vim82/plugin/logiPat.vim
038.159  000.034  000.034: sourcing /usr/local/share/vim/vim82/plugin/manpager.vim
038.449  000.216  000.216: sourcing /usr/local/share/vim/vim82/plugin/matchparen.vim
039.093  000.557  000.557: sourcing /usr/local/share/vim/vim82/plugin/netrwPlugin.vim
039.217  000.016  000.016: sourcing /usr/local/share/vim/vim82/plugin/rrhelper.vim
039.337  000.032  000.032: sourcing /usr/local/share/vim/vim82/plugin/spellfile.vim
039.604  000.182  000.182: sourcing /usr/local/share/vim/vim82/plugin/tarPlugin.vim
039.814  000.118  000.118: sourcing /usr/local/share/vim/vim82/plugin/tohtml.vim
040.085  000.184  000.184: sourcing /usr/local/share/vim/vim82/plugin/vimballPlugin.vim
040.428  000.237  000.237: sourcing /usr/local/share/vim/vim82/plugin/zipPlugin.vim
```

With the fix above the result is as follows:

```
rm -f /tmp/startup.log && vim -N -u ~/.vimrc.test --startuptime /tmp/startup.log -c q && cat /tmp/startup.log | grep sourcing
021.896  006.529  006.529: sourcing /Users/sheerun/.vim/autoload/plug.vim
031.992  000.019  000.019: sourcing /usr/local/share/vim/vimfiles/ftdetect/pullrequest.vim
032.120  007.904  007.885: sourcing /usr/local/share/vim/vim82/filetype.vim
032.319  000.047  000.047: sourcing /usr/local/share/vim/vim82/ftplugin.vim
032.506  000.045  000.045: sourcing /usr/local/share/vim/vim82/indent.vim
033.768  000.832  000.832: sourcing /usr/local/share/vim/vim82/syntax/syncolor.vim
033.893  001.101  000.269: sourcing /usr/local/share/vim/vim82/syntax/synload.vim
033.927  001.281  000.180: sourcing /usr/local/share/vim/vim82/syntax/syntax.vim
033.942  018.761  002.955: sourcing /Users/sheerun/.vimrc.test
033.949  000.258: sourcing vimrc file(s)
036.137  000.325  000.325: sourcing /usr/local/Cellar/vim/8.2.1700/share/vim/vim82/pack/dist/opt/matchit/plugin/matchit.vim
036.210  001.075  000.750: sourcing /usr/local/share/vim/vim82/macros/matchit.vim
036.272  002.029  000.954: sourcing /Users/sheerun/.vim/plugged/vim-sensible/plugin/sensible.vim
037.219  000.073  000.073: sourcing /usr/local/share/vim/vim82/plugin/getscriptPlugin.vim
037.677  000.380  000.380: sourcing /usr/local/share/vim/vim82/plugin/gzip.vim
038.035  000.274  000.274: sourcing /usr/local/share/vim/vim82/plugin/logiPat.vim
038.154  000.036  000.036: sourcing /usr/local/share/vim/vim82/plugin/manpager.vim
038.448  000.218  000.218: sourcing /usr/local/share/vim/vim82/plugin/matchparen.vim
039.097  000.561  000.561: sourcing /usr/local/share/vim/vim82/plugin/netrwPlugin.vim
039.220  000.016  000.016: sourcing /usr/local/share/vim/vim82/plugin/rrhelper.vim
039.343  000.031  000.031: sourcing /usr/local/share/vim/vim82/plugin/spellfile.vim
039.607  000.178  000.178: sourcing /usr/local/share/vim/vim82/plugin/tarPlugin.vim
039.832  000.125  000.125: sourcing /usr/local/share/vim/vim82/plugin/tohtml.vim
040.107  000.184  000.184: sourcing /usr/local/share/vim/vim82/plugin/vimballPlugin.vim
040.451  000.238  000.238: sourcing /usr/local/share/vim/vim82/plugin/zipPlugin.vim
```

As you can see no double-loading is happening.

Additionally enabling separately `indent` and `plugin` safeguards against similar bug that is happening when user enabled one but not the other.