### PR TITLE
Remapped shift-tab to tab leftwards in insert mode.

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -97,5 +97,8 @@ endif
 if empty(mapcheck('<C-W>', 'i'))
   inoremap <C-W> <C-G>u<C-W>
 endif
+if empty(mapcheck('<S-Tab>', 'i'))
+  inoremap <S-Tab> <C-d>
+endif
 
 " vim:set ft=vim et sw=2:


### PR DESCRIPTION
Many programs (Notepad++, Microsoft Word, Sublime Text, GNU nano, VS Code, etc.) map shift-tab to an inverse tab. Vim, by default, does not map this to anything, and when the combination is pressed, a regular tab character is inserted.

I think it might be a good tweak to add this mapping if Shift-Tab in insert mode is not mapped to anything else :)