### PR TITLE
Fix MaySet detection for Neovim init.lua users.

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -26,7 +26,7 @@ function! s:MaySet(option) abort
     silent verbose execute 'setglobal all' a:option . '?'
     redir END
   endif
-  return out !~# " \\~[\\/][^\n]*$"
+  return out !~# " \\(\\~[\\/][^\n]*\\|Lua\\)$"
 endfunction
 
 if s:MaySet('backspace')


### PR DESCRIPTION
Neovim users since version 0.5 can write their global configuration in an ~/.config/nvim/init.lua file instead of ~/.config/nvim/init.vim.

Unfortunately, `:verbose` support for Lua is still lacking even in Neovim 0.8: instead of reporting the file and line that last changed an option, it will simply say "last set in Lua" if that change happened in a Lua script.

The regex used in MaySet does not recognize this case and so MaySet falsely assumes that all Lua config comes from the system and not from the user.

I've gone for a somewhat hacky solution and simply added the alternative `/ Lua$/` to the regex. This assumes that the system-wide vimrc file is always written in VimScript – which is true to this day according to the [Neovim documentation][1].

[1]: https://github.com/neovim/neovim/blob/ce0fddf5/runtime/doc/starting.txt#L468-L472