### PR TITLE
Fix MaySet detection for Lua following update

### DIFF
--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -26,7 +26,7 @@ function! s:MaySet(option) abort
     silent verbose execute 'setglobal all' a:option . '?'
     redir END
   endif
-  return out !~# " \\(\\~[\\/][^\n]*\\|Lua\\)$"
+  return out !~# " \\(\\~[\\/][^\n]*\\|Lua.*\\)$"
 endfunction
 
 if s:MaySet('backspace')

--- a/plugin/sensible.vim
+++ b/plugin/sensible.vim
@@ -26,7 +26,7 @@ function! s:MaySet(option) abort
     silent verbose execute 'setglobal all' a:option . '?'
     redir END
   endif
-  return out !~# " \\(\\~[\\/][^\n]*\\|Lua.*\\)$"
+  return out !~# " \\(\\~[\\/]\\|Lua\\)[^\n]*$"
 endfunction
 
 if s:MaySet('backspace')


### PR DESCRIPTION
With version v0.10.0 of Neovim, the `:verbose` output added "(run Nvim with -V1 for more details)" to the previous message, which was simply "Last set from Lua".
(see [commit][1])

The issue now is that the previous regex, done in #187, doesn't capture the rest of the message anymore for users of Neovim v0.10.0.

The basic solution I found is to add `.*` to the regex to add the possibility of capturing the rest of the message.

[1]: https://github.com/neovim/neovim/commit/77d3526a3d088b16e4f07e84c79cbd4a3411d0fe